### PR TITLE
Switch to OpenAI and add statement storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ A professional AI Assistant application with screen sharing, voice chat, and tex
 
 ## Features
 
-- **Dual Bot System**: Clay and Reese chatbots with configurable App IDs
+- **Dual Bot System**: Clay and Reese chatbots with configurable model IDs
 - **Voice Chat**: Real-time voice interaction with speech-to-text and text-to-speech
 - **Screen Sharing**: Share your screen and get AI assistance with visual content
 - **Text Chat**: Traditional text-based conversation interface
 - **Modern UI**: Dark theme with professional design using Tailwind CSS and shadcn/ui
+- **Persistent Storage**: Save and retrieve statements and documentation
 
 ## Technology Stack
 
 - **Frontend**: Next.js 14, React, TypeScript
 - **UI Components**: shadcn/ui, Radix UI, Tailwind CSS
-- **Database**: Prisma ORM with SQLite
-- **AI Integration**: Abacus.AI API
+- **Database**: Prisma ORM with SQLite for bot configuration and statement storage
+- **AI Integration**: OpenAI GPT models
 - **Voice**: Web Speech API
 - **Screen Sharing**: WebRTC Screen Capture API
 
@@ -25,11 +26,11 @@ A professional AI Assistant application with screen sharing, voice chat, and tex
 2. Install dependencies: `npm install`
 3. Set up environment variables
 4. Run the development server: `npm run dev`
-5. Configure your Clay and Reese App IDs in the settings
+5. Configure your Clay and Reese model IDs in the settings
 
 ## Configuration
 
-The application requires Abacus.AI App IDs for Clay and Reese chatbots. Configure these through the settings modal in the application.
+The application uses OpenAI models for Clay and Reese chatbots. Configure their model IDs through the settings modal in the application.
 
 ## Project Structure
 

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,3 @@
+# Environment variables for MND Assistant
+DATABASE_URL="file:./prisma/dev.db"
+OPENAI_API_KEY="your-openai-api-key"

--- a/app/.gitignore
+++ b/app/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+.env
+.env.local
+.env.production
+.env.development
+.next/
+prisma/dev.db

--- a/app/app/api/bot-config/[botName]/route.ts
+++ b/app/app/api/bot-config/[botName]/route.ts
@@ -40,7 +40,7 @@ export async function GET(
 
     return NextResponse.json({
       botName,
-      appId: botConfig.appId,
+      appId: botConfig.appId, // OpenAI model id
       isActive: botConfig.isActive
     })
 

--- a/app/app/api/bot-config/route.ts
+++ b/app/app/api/bot-config/route.ts
@@ -62,25 +62,26 @@ export async function POST(request: NextRequest) {
       }
     })
 
-    // Test the bot configuration by making a simple API call
+    // Test the bot configuration by making a simple API call to OpenAI
+    // Here, the provided appId is treated as the OpenAI model name
     let testSuccess = true
     try {
-      const testResponse = await fetch('https://apps.abacus.ai/v1/chat/completions', {
+      const testResponse = await fetch('https://api.openai.com/v1/chat/completions', {
         method: 'POST',
         headers: {
-          'Authorization': `Bearer ${process.env.ABACUSAI_API_KEY}`,
-          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`,
+          'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          model: 'gpt-4.1-mini',
+          model: appId.trim(),
           messages: [
             {
               role: 'user',
               content: 'Hello, this is a test message.'
             }
           ],
-          max_tokens: 10,
-        }),
+          max_tokens: 10
+        })
       })
 
       if (!testResponse.ok) {

--- a/app/app/api/statements/route.ts
+++ b/app/app/api/statements/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { PrismaClient } from '@prisma/client'
+
+const prisma = new PrismaClient()
+
+export async function GET() {
+  try {
+    const statements = await prisma.statement.findMany({
+      orderBy: { createdAt: 'desc' }
+    })
+    return NextResponse.json({ statements })
+  } catch (error) {
+    console.error('Statements get API error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { title, content } = await request.json()
+
+    if (!title || !content) {
+      return NextResponse.json(
+        { error: 'Title and content are required' },
+        { status: 400 }
+      )
+    }
+
+    const statement = await prisma.statement.create({
+      data: {
+        title: title.trim(),
+        content: content.trim(),
+        userId: 'default-user'
+      }
+    })
+
+    return NextResponse.json({ statement })
+  } catch (error) {
+    console.error('Statements post API error:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -1,0 +1,37 @@
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id         String      @id
+  email      String      @unique
+  botConfigs BotConfig[]
+  statements Statement[]
+}
+
+model BotConfig {
+  id        Int      @id @default(autoincrement())
+  user      User     @relation(fields: [userId], references: [id])
+  userId    String
+  botName   String
+  appId     String
+  isActive  Boolean  @default(true)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([userId, botName])
+}
+
+model Statement {
+  id        Int      @id @default(autoincrement())
+  user      User?    @relation(fields: [userId], references: [id])
+  userId    String?
+  title     String
+  content   String
+  createdAt DateTime @default(now())
+}


### PR DESCRIPTION
## Summary
- replace Abacus.AI calls with OpenAI chat completions
- add Prisma schema and API route for storing statements
- document new environment variables and OpenAI setup

## Testing
- `npm install` *(fails: @radix-ui/react-sheet not found)*
- `npm run lint` *(fails: next not found)*
- `npx prisma validate` *(fails: requires interactive package install)*

------
https://chatgpt.com/codex/tasks/task_e_689fd34a88b8832ea09ec33465908215